### PR TITLE
Add OpenGraph meta tags to the default templates.

### DIFF
--- a/src/simple_theme/templates/base.tpl
+++ b/src/simple_theme/templates/base.tpl
@@ -5,6 +5,11 @@
   <meta name="generator" content="mdblog.rs">
   <link rel="icon" href="{{ config.site_url }}/static/favicon.png">
   <link rel="stylesheet" href="{{ config.site_url }}/static/main.css">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="{{ config.site_name }}" />
+  <meta property="og:description" content="{{ config.site_motto }}" />
+  <meta property="og:url" content="{{ config.site_url }}" />
+  <meta property="og:image" content="{{ config.site_url }}/static/logo.png" />
   {%- block css %}{% endblock css -%}
   {%- block title %}{% endblock title -%}
 </head>

--- a/src/simple_theme/templates/index.tpl
+++ b/src/simple_theme/templates/index.tpl
@@ -2,6 +2,7 @@
 
 {% block title %}
   <title>{{ config.site_name }}</title>
+  <meta property="og:title" content="{{ config.site_name }}" />
 {% endblock title %}
 
 {% block css %}{% endblock css %}

--- a/src/simple_theme/templates/post.tpl
+++ b/src/simple_theme/templates/post.tpl
@@ -2,6 +2,7 @@
 
 {% block title %}
   <title>{{ post.title }}</title>
+  <meta property="og:title" content="{{ post.title }}" />
 {% endblock title %}
 
 {%- block css %}

--- a/src/simple_theme/templates/tag.tpl
+++ b/src/simple_theme/templates/tag.tpl
@@ -2,6 +2,7 @@
 
 {% block title %}
   <title>{{ title }}</title>
+  <meta property="og:title" content="{{ title }}" />
 {% endblock title %}
 
 {%- block css %}{% endblock css -%}


### PR DESCRIPTION
Allows generated blogs to appear in Discord thumbnails, for example
![image](https://user-images.githubusercontent.com/65794972/94716617-1ff4bd80-031d-11eb-9d50-05bccfbf8fff.png)
